### PR TITLE
Uninstall javascript widgets instead of disabling them

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,10 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   script: python setup.py install --conda --single-version-externally-managed --record record.txt
+# we can not use noarch, because pre/post-link scripts for install/uninstall of nbwidgets are not avail then.
+#  noarch: python
 
 requirements:
   build:

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,3 +1,3 @@
 @echo off
 
-"%PREFIX%\Scripts\jupyter-nbextension.exe" disable nglview --py --sys-prefix > NUL 2>&1 && if errorlevel 1 exit 1
+"%PREFIX%\Scripts\jupyter-nbextension.exe" uninstall nglview --py --sys-prefix :: > NUL 2>&1 && if errorlevel 1 exit 1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,1 +1,1 @@
-"${PREFIX}/bin/jupyter-nbextension" disable nglview --py --sys-prefix > /dev/null 2>&1
+"${PREFIX}/bin/jupyter-nbextension" uninstall nglview --py --sys-prefix #> /dev/null 2>&1


### PR DESCRIPTION
to avoid version conflicts with old installations, we ensure we get rid off the old js widgets.