### PR TITLE
pin exact range for widgetsnbextensions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 3
+  number: 4
   script: python setup.py install --conda --single-version-externally-managed --record record.txt
 # we can not use noarch, because pre/post-link scripts for install/uninstall of nbwidgets are not avail then.
 #  noarch: python
@@ -29,6 +29,8 @@ requirements:
     - notebook
     # TODO: unpin after https://github.com/arose/nglview/issues/726 has been fixed/released.
     - ipykernel <4.7
+    # nglview wants ~=3.0.0 (eg. a patch release of 3.0 major)
+    - widgetsnbextension <3.1,>3.0
 
 test:
   imports:


### PR DESCRIPTION
This fixes the following exception.

pkg_resources.DistributionNotFound: The 'widgetsnbextension~=3.0.0' distribution was not found and is required by ipywidgets